### PR TITLE
[#142] Force webhooks body encoding to UTF-8

### DIFF
--- a/app/services/github/webhook_request_wrapper.rb
+++ b/app/services/github/webhook_request_wrapper.rb
@@ -10,7 +10,7 @@ module Github
 
     def self.build(request)
       new(
-        raw_body: request.body.read,
+        raw_body: request.body.set_encoding("UTF-8").read,
         hub_signature: request.env["HTTP_X_HUB_SIGNATURE"],
         github_event: request.env["HTTP_X_GITHUB_EVENT"]
       )


### PR DESCRIPTION
fixed #142 
---
[Create QA instance](https://deployqa.dev/projects/2/project_instances/42/deploy)
[Create custom QA instance](https://deployqa.dev/projects/2/project_instances/42/deploy?custom_deploy=true)
[Configuration](https://deployqa.dev/projects/2/project_instances/42)
