### PR TITLE
[#245] Add deployQA bot with developer permissions at once

### DIFF
--- a/app/services/gitlab_integration/repository_creator.rb
+++ b/app/services/gitlab_integration/repository_creator.rb
@@ -13,7 +13,6 @@ module GitlabIntegration
 
       @git_client_wrapper.add_deployqa_bot_to_repo(repository, permission: :maintainer)
       @git_client_wrapper.add_webhook_to_repo(repository)
-      @git_client_wrapper.change_deployqa_bot_permission(repository, permission: :developer)
 
       ReturnValue.ok(repository)
     end

--- a/lib/provider_api/gitlab/user_client.rb
+++ b/lib/provider_api/gitlab/user_client.rb
@@ -23,12 +23,6 @@ module ProviderAPI
         gitlab_client.add_team_member(repository.integration_id, ENV["GITLAB_DEPLOYQA_BOT_ID"], permission_code)
       end
 
-      def change_deployqa_bot_permission(repository, permission: :guest)
-        permission_code = GITLAB_MEMBER_PERMISSIONS.fetch(permission)
-
-        gitlab_client.edit_team_member(repository.integration_id, ENV["GITLAB_DEPLOYQA_BOT_ID"], permission_code)
-      end
-
       def load_groups
         gitlab_client.groups(min_access_level: GITLAB_MEMBER_PERMISSIONS[:maintainer])
       end


### PR DESCRIPTION
Fixes #245

A User sees the repositories where they are maintainer or owner, so they will have permissions to add a new member and add a webhook

---
[<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run.png' align='absmiddle' title='Deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/505/deploy) [<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run_with_setup_dark.png' align='absmiddle' title='Customize and deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/505/deploy?custom_deploy=true) [<img height="70" width="50" src='https://deployqa-production.s3.amazonaws.com/public-icons/setup.png' align='absmiddle' title='Open instance page' />](https://deployqa.dev/projects/2/project_instances/505)
