### PR TITLE
Fix gitlab project addition. User wrapper used to use github token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :login_if_not
   before_action :set_paper_trail_whodunnit
 
-  helper_method :github_router
+  helper_method :github_router, :gitlab_router
 
   private
 

--- a/app/controllers/gitlab_integration/projects_controller.rb
+++ b/app/controllers/gitlab_integration/projects_controller.rb
@@ -26,7 +26,7 @@ module GitlabIntegration
 
     def complete_project_params
       project_params.merge(
-        name: ProjectPage.new(current_user).namespace_by_id(project_params[:integration_id]).name,
+        name: GitlabIntegration::ProjectPage.new(current_user).namespace_by_id(project_params[:integration_id]).path,
         integration_type: ProjectsConstants::Providers::GITLAB
       )
     end

--- a/app/controllers/gitlab_integration/repositories_controller.rb
+++ b/app/controllers/gitlab_integration/repositories_controller.rb
@@ -41,7 +41,7 @@ module GitlabIntegration
     end
 
     def gitlab_client_wrapper
-      ::ProviderAPI::Gitlab::UserClient.new(current_user.token)
+      ::ProviderAPI::Gitlab::UserClient.new(current_user.token_for(::ProjectsConstants::Providers::GITLAB))
     end
   end
 end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -10,7 +10,8 @@ module ProjectHelper
   def link_to_project_orgatnization(project)
     return project_integration_logo(project) if project.integration_type == ProjectsConstants::Providers::VIA_SSH
 
-    link_to(github_router.page_url(project.name), target: :_blank) do
+    router = project.integration_type == ::ProjectsConstants::Providers::GITHUB ? github_router : gitlab_router
+    link_to(router.page_url(project.name), target: :_blank) do
       project_integration_logo(project)
     end + " "
   end

--- a/app/pages/gitlab_integration/project_page.rb
+++ b/app/pages/gitlab_integration/project_page.rb
@@ -4,7 +4,7 @@ module GitlabIntegration
   class ProjectPage
     def initialize(current_user)
       @current_user = current_user
-      @gitlab_client = ::ProviderAPI::Gitlab::UserClient.new(@current_user.token)
+      @gitlab_client = ::ProviderAPI::Gitlab::UserClient.new(current_user.token_for(::ProjectsConstants::Providers::GITLAB))
     end
 
     def build_project_names

--- a/app/services/auth/user_wrapper.rb
+++ b/app/services/auth/user_wrapper.rb
@@ -21,8 +21,8 @@ module Auth
       auth_info.email
     end
 
-    def token
-      auth_info.token
+    def token_for(provider)
+      @user.user_references.find { |user_reference| user_reference.auth_provider == provider }.auth_info.token
     end
 
     def actual_user

--- a/app/services/gitlab_integration/project_creator.rb
+++ b/app/services/gitlab_integration/project_creator.rb
@@ -22,7 +22,7 @@ module GitlabIntegration
     attr_reader :project_params, :current_user
 
     def load_gitlab_repositories
-      repositories = ::ProviderAPI::Gitlab::UserClient.new(current_user.token).load_repositories
+      repositories = ::ProviderAPI::Gitlab::UserClient.new(current_user.token_for(::ProjectsConstants::Providers::GITLAB)).load_repositories
       repositories.filter { |repository| repository.namespace.id == @project_params[:integration_id].to_i }
     end
 

--- a/app/services/gitlab_integration/router.rb
+++ b/app/services/gitlab_integration/router.rb
@@ -7,5 +7,9 @@ module GitlabIntegration
     def merge_request_url(repo_path, mr_number)
       GITLAB_HOST + "#{repo_path}/merge_requests/#{mr_number}"
     end
+
+    def page_url(page_id)
+      GITLAB_HOST + page_id
+    end
   end
 end

--- a/app/services/server_access/heroku.rb
+++ b/app/services/server_access/heroku.rb
@@ -21,7 +21,7 @@ module ServerAccess
     end
 
     def push_buildpacks(buildpacks)
-      return ReturnValue.ok unless buildpacks.any? { |buildpack| buildpack.present? }
+      return ReturnValue.ok unless buildpacks.any?(&:present?)
 
       updates = buildpacks.map { |buildpack| { buildpack: buildpack } }
       safe_call.safely do

--- a/app/views/gitlab_integration/projects/new.html.slim
+++ b/app/views/gitlab_integration/projects/new.html.slim
@@ -11,5 +11,5 @@
     = simple_form_for @project, url: gitlab_projects_path, method: :post do |form|
       - if @project.errors.any?
         p = @project.errors.full_messages
-      = form.input :integration_id, collection: @names, label: "Name", include_blank: false
+      = form.input :integration_id, collection: @names, label: "Name of organization", include_blank: false
       = form.button :submit, class: "btn btn-primary"


### PR DESCRIPTION
…lso few small fixes

---
[<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run.png' align='absmiddle' title='Deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/706/deploy) [<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run_with_setup_dark.png' align='absmiddle' title='Customize and deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/706/deploy?custom_deploy=true) [<img height="70" width="50" src='https://deployqa-production.s3.amazonaws.com/public-icons/setup.png' align='absmiddle' title='Open instance page' />](https://deployqa.dev/projects/2/project_instances/706)
