### PR TITLE
Remove NomadReferences after project instance destroy

### DIFF
--- a/app/services/robad/events/handler.rb
+++ b/app/services/robad/events/handler.rb
@@ -23,6 +23,9 @@ module Robad
         end
         old_references.each(&:destroy!)
       end
+      DESTROY_INSTANCE_HANDLER = lambda do |_configuration, build_action, _tasks|
+        NomadReference.where(project_instance_id: build_action.project_instance_id).destroy_all
+      end
 
       EVENTS = {
         "deployment/status/start" => {
@@ -30,7 +33,9 @@ module Robad
           BuildActionConstants::RECREATE_INSTANCE => CREATE_ADDONS_HANDLER,
           BuildActionConstants::DESTROY_INSTANCE => DELETE_ADDONS_HANDLER
         },
-        "deployment/status/success" => {},
+        "deployment/status/success" => {
+          BuildActionConstants::DESTROY_INSTANCE => DESTROY_INSTANCE_HANDLER
+        },
         "deployment/status/failure" => {
           BuildActionConstants::CREATE_INSTANCE => DELETE_ADDONS_HANDLER,
           BuildActionConstants::RECREATE_INSTANCE => DELETE_ADDONS_HANDLER


### PR DESCRIPTION


---
[<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run.png' align='absmiddle' title='Deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/1761/deploy) [<img height="70" width="70" src='https://deployqa-production.s3.amazonaws.com/public-icons/run_with_setup_dark.png' align='absmiddle' title='Customize and deploy branch via DeployQA' />](https://deployqa.dev/projects/2/project_instances/1761/deploy?custom_deploy=true) [<img height="70" width="50" src='https://deployqa-production.s3.amazonaws.com/public-icons/setup.png' align='absmiddle' title='Open instance page' />](https://deployqa.dev/projects/2/project_instances/1761)
